### PR TITLE
JDBC does not maintain a list of active results

### DIFF
--- a/R/DBI-pool.R
+++ b/R/DBI-pool.R
@@ -17,6 +17,10 @@ setMethod("dbDisconnect", "DBIConnection", function(conn, ...) {
   poolReturn(conn)
 })
 
+
+setMethod("onPassivate", "JDBCConnection", function(object) {
+  ""
+})
 ## Ideally this would also reset the connection more fully (ex: reset
 ## all user-defined variables set with `SET` back to their default values).
 ## Currently, there isn't a handy dbResetConnection() generic in DBI, so

--- a/R/DBI-pool.R
+++ b/R/DBI-pool.R
@@ -17,13 +17,6 @@ setMethod("dbDisconnect", "DBIConnection", function(conn, ...) {
   poolReturn(conn)
 })
 
-#'
-#' @export
-#' @rdname object
-setMethod("onPassivate", "JDBCConnection", function(object) {
-  NULL
-})
-
 ## Ideally this would also reset the connection more fully (ex: reset
 ## all user-defined variables set with `SET` back to their default values).
 ## Currently, there isn't a handy dbResetConnection() generic in DBI, so
@@ -37,6 +30,9 @@ setMethod("onPassivate", "JDBCConnection", function(object) {
 #' @export
 #' @rdname object
 setMethod("onPassivate", "DBIConnection", function(object) {
+  if (inherits(object, "JDBCConnection")){
+    return(NULL)
+  }
   rs <- dbListResults(object)
   lapply(rs, function(x) {
     if (dbIsValid(x)) {

--- a/R/DBI-pool.R
+++ b/R/DBI-pool.R
@@ -17,10 +17,13 @@ setMethod("dbDisconnect", "DBIConnection", function(conn, ...) {
   poolReturn(conn)
 })
 
-
+#'
+#' @export
+#' @rdname object
 setMethod("onPassivate", "JDBCConnection", function(object) {
-  ""
+  NULL
 })
+
 ## Ideally this would also reset the connection more fully (ex: reset
 ## all user-defined variables set with `SET` back to their default values).
 ## Currently, there isn't a handy dbResetConnection() generic in DBI, so

--- a/R/DBI-pool.R
+++ b/R/DBI-pool.R
@@ -30,7 +30,7 @@ setMethod("dbDisconnect", "DBIConnection", function(conn, ...) {
 #' @export
 #' @rdname object
 setMethod("onPassivate", "DBIConnection", function(object) {
-  if (inherits(object, "JDBCConnection")){
+  if (inherits(object, "JDBCConnection") | inherits(object, "SQLServerConnection")){
     return(NULL)
   }
   rs <- dbListResults(object)

--- a/man/object.Rd
+++ b/man/object.Rd
@@ -11,6 +11,7 @@
 \alias{onPassivate}
 \alias{onPassivate,ANY-method}
 \alias{onPassivate,DBIConnection-method}
+\alias{onPassivate,JDBCConnection-method}
 \alias{onValidate}
 \alias{onValidate,ANY-method}
 \alias{onValidate,DBIConnection-method}
@@ -23,6 +24,8 @@ onPassivate(object)
 onDestroy(object)
 
 onValidate(object, query)
+
+\S4method{onPassivate}{JDBCConnection}(object)
 
 \S4method{onPassivate}{DBIConnection}(object)
 
@@ -41,5 +44,7 @@ For backend authors only. Authors should implement all of these,
 which are then called by the Pool class methods. These should
 not be called directly either by backend authors or by the end
 users.
+
+export
 }
 

--- a/man/object.Rd
+++ b/man/object.Rd
@@ -11,7 +11,6 @@
 \alias{onPassivate}
 \alias{onPassivate,ANY-method}
 \alias{onPassivate,DBIConnection-method}
-\alias{onPassivate,JDBCConnection-method}
 \alias{onValidate}
 \alias{onValidate,ANY-method}
 \alias{onValidate,DBIConnection-method}
@@ -24,8 +23,6 @@ onPassivate(object)
 onDestroy(object)
 
 onValidate(object, query)
-
-\S4method{onPassivate}{JDBCConnection}(object)
 
 \S4method{onPassivate}{DBIConnection}(object)
 
@@ -44,7 +41,5 @@ For backend authors only. Authors should implement all of these,
 which are then called by the Pool class methods. These should
 not be called directly either by backend authors or by the end
 users.
-
-export
 }
 


### PR DESCRIPTION
This addresses the issue mentioned by @ClaytonJY in the [RSQLServer support discussion](https://github.com/rstudio/pool/issues/20#issuecomment-249274457) and is related to the original comment by @jfredtx regarding identification of the driver.

In `pool::dbGetQuery()` the connection object is released back into the pool on exit. This wraps the `poolReturn` method and calls `pool$release(object)`. This calls `onPassivate(object)` ([pool.R L114](https://github.com/rstudio/pool/blob/master/R/pool.R#L114)). The `onPassivate` method for a `DBIConnection` object will then call `DBI::dbListResults(object)` ([DBI-pool.R L32](https://github.com/rstudio/pool/blob/master/R/DBI-pool.R#L32)).

The `RJDBC` package extends `DBI` and a JDBC connection inherits the DBI connection class. When pool calls `dbListResults` on the object this produces the warning ([definition for RJDBC dbListResults](https://github.com/s-u/RJDBC/blob/master/R/class.R#L150)).

As I understand it, the `onPassivate` method for a DBI connection is to "reset" by clearing out active results. Since JDBC does not maintain a list of active results, nothing happens here. I'm certainly not an expert in this area, so I'm not sure whether anything _should_ happen or _needs_ to happen to . In any case I suspect that would require a modification to the RJDBC package.
