### PR TITLE
Fix for determining interval for validating objects

### DIFF
--- a/R/pool.R
+++ b/R/pool.R
@@ -302,20 +302,17 @@ Pool <- R6::R6Class("Pool",
     ## secs have passed since the last validation (this allows
     ## us some performance gains)
     validate = function(object) {
-      message("Checking whether to validate object")
       pool_metadata <- attr(object, "pool_metadata", exact = TRUE)
       lastValidated <- pool_metadata$lastValidated
       ## if the object has never been validated, set `lastValidated`
       ## to guarantee that it will be validated now
       if (is.null(lastValidated)) {
-        message("Never validated")
         lastValidated <- Sys.time() - self$validationInterval
       }
 
       interval <- difftime(Sys.time(), lastValidated, units = "secs") # ensure the interval is returned in seconds
 
       if (interval >= self$validationInterval) {
-        message("Validating object")
         onValidate(object)
         pool_metadata$lastValidated <- Sys.time()
       }

--- a/R/pool.R
+++ b/R/pool.R
@@ -302,15 +302,18 @@ Pool <- R6::R6Class("Pool",
     ## secs have passed since the last validation (this allows
     ## us some performance gains)
     validate = function(object) {
+      message("Checking whether to validate object")
       pool_metadata <- attr(object, "pool_metadata", exact = TRUE)
       lastValidated <- pool_metadata$lastValidated
       ## if the object has never been validated, set `lastValidated`
       ## to guarantee that it will be validated now
       if (is.null(lastValidated)) {
+        message("Never validated")
         lastValidated <- Sys.time() - self$validationInterval
       }
-      interval <- Sys.time() - lastValidated
+      interval <- difftime(Sys.time(), lastValidated, units = "secs") # ensure the interval is returned in seconds
       if (interval >= self$validationInterval) {
+        message("Validating object")
         onValidate(object)
         pool_metadata$lastValidated <- Sys.time()
       }


### PR DESCRIPTION
Fix for determining interval for validating objects. Sys.time - lastValidated can result in minutes or other units; use difftime to force the result to be in seconds.