### PR TITLE
Fix usage of sqlInterpolate (#76)

### DIFF
--- a/R/DBI-connection-interpolate.R
+++ b/R/DBI-connection-interpolate.R
@@ -19,11 +19,7 @@ NULL
 setMethod("sqlInterpolate", "Pool", function(conn, sql, ..., .dots = list()) {
   connection <- poolCheckout(conn)
   on.exit(poolReturn(connection))
-  if (identical(list(), .dots)) {
-    DBI::sqlInterpolate(connection, sql, ...)
-  } else {
-    DBI::sqlInterpolate(connection, sql, .dots = .dots)
-  }
+  DBI::sqlInterpolate(connection, sql, ..., .dots = .dots)
 })
 
 #' @export


### PR DESCRIPTION
This PR addresses #76.

Since `sqlInterpolate` accepts both `...` and `.dots` at the same time (See https://github.com/r-dbi/DBI/blob/master/R/interpolate.R#L47), the following code is valid

```r
sqlInterpolate(con, "select * from table where date = ?date and time = ?time", 
  date = "2018-01-01", .dots = list(time = "09:30:00"))
```

When `date` and `time` are specified in `...` and `.dots` specifically, it should also work.