### PR TITLE
Allow warn level > 1 in tasks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pool
 Type: Package
 Title: Object Pooling
-Version: 0.1.4
+Version: 0.1.4.9000
 Authors@R: c(
     person("Barbara", "Borges", email = "barbara@rstudio.com",
       role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+pool 0.1.4.9000
+================
+
+* Previously, pool would always set `options(warn=1)` when running tasks. It now ensures that the value of `warn` can be 1 or greater. This can be useful in debugging, so that `options(warn=2)` can be used. ([#90](https://github.com/rstudio/pool/pull/90))
+
 pool 0.1.4
 ================
 

--- a/R/scheduler.R
+++ b/R/scheduler.R
@@ -7,9 +7,10 @@ scheduleTask <- function(func, delay) {
   later::later(function() {
     # Make sure warn is at least 1 so that warnings are emitted immediately.
     # (warn=2 is also OK, for use in debugging.)
-    if (getOption("warn") < 1) {
+    warn_level <- getOption("warn")
+    if (is.numeric(warn_level) && !is.na(warn_level) && warn_level < 1) {
       op <- options(warn = 1)
-      on.exit(options(op))
+      on.exit(options(op), add = TRUE)
     }
     if (!is.null(func))
       func()

--- a/R/scheduler.R
+++ b/R/scheduler.R
@@ -5,8 +5,12 @@ NULL
 scheduleTask <- function(func, delay) {
   force(func)
   later::later(function() {
-    op <- options(warn = 1)
-    on.exit(options(op))
+    # Make sure warn is at least 1 so that warnings are emitted immediately.
+    # (warn=2 is also OK, for use in debugging.)
+    if (getOption("warn") < 1) {
+      op <- options(warn = 1)
+      on.exit(options(op))
+    }
     if (!is.null(func))
       func()
   }, delay)

--- a/tests/testthat/test-create-destroy.R
+++ b/tests/testthat/test-create-destroy.R
@@ -44,7 +44,11 @@ describe("destroyObject", {
         "Object of class MockPooledObj could not be ",
         "destroyed properly, but was successfully removed ",
         "from pool."
-      )
+      ),
+      # The class seems redundant, but is necessary for this test to not throw
+      # an unnecessary error with later<1.0.0. It can be removed in the future
+      # after later 1.0.0 has been released.
+      class = "error"
     )
 
     checkCounts(pool, free = 0, taken = 1)

--- a/tests/testthat/test-create-destroy.R
+++ b/tests/testthat/test-create-destroy.R
@@ -28,13 +28,23 @@ describe("destroyObject", {
     ## since we're over the minSize, once we return `b` to
     ## the pool, it will be destroyed immediately (since
     ## we set `idleTimeout = 0`)
-    expect_warning({
+    #
+    # Previously, the expect_error() below was a expect_warning(), but a
+    # change in later 1.0.0 altered the way that warnings are handled; they no
+    # longer pass up through run_now(). A future version of later may change
+    # that back to the original behavior. The workaround is to convert the
+    # warning to an error and look for the error.
+    op <- options(warn = 2)
+    on.exit(options(op), add = TRUE)
+    expect_error({
         poolReturn(b)
         later::run_now() # this is needed so that the scheduler runs NOW
       },
-      "Object of class MockPooledObj could not be ",
-      "destroyed properly, but was successfully removed ",
-      "from pool."
+      regexp = paste0(
+        "Object of class MockPooledObj could not be ",
+        "destroyed properly, but was successfully removed ",
+        "from pool."
+      )
     )
 
     checkCounts(pool, free = 0, taken = 1)


### PR DESCRIPTION
This PR also makes pool work properly with later 1.0.0.