### PR TITLE
Use setDBIMethod()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
     R (>= 3.0.0),
     methods
 Imports:
-    DBI,
+    DBI (>= 1.0.0.9003),
     R6,
     dplyr,
     dbplyr,
@@ -30,7 +30,10 @@ Suggests:
 URL: https://github.com/rstudio/pool
 BugReports: https://github.com/rstudio/pool/issues
 LazyData: TRUE
+Remotes: 
+    r-dbi/DBI
 Collate:
+    's4.R'
     'utils.R'
     'scheduler.R'
     'pool.R'

--- a/R/s4.R
+++ b/R/s4.R
@@ -1,0 +1,1 @@
+setMethod <- DBI::setDBIMethod

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,6 @@
+#' @include s4.R
+NULL
+
 #' Object Pooling in R.
 #'
 #' Creates objects pools for various types of objects in R to


### PR DESCRIPTION
I'd like to rename the `con` argument to `sqlData()` to `conn` in r-dbi/DBI#285. This change allows me to do so in the future without introducing a breaking change which would be very unpleasant to deal with. Also, it opens up the potential to clean up the definition of the DBI interface.

See https://dbi.r-dbi.org/dev/reference/setdbimethod for details.