### PR TITLE
Add dbQuoteLiteral() method

### DIFF
--- a/R/DBI-connection-quote.R
+++ b/R/DBI-connection-quote.R
@@ -24,6 +24,16 @@ setMethod("dbQuoteIdentifier", c("Pool", "ANY"),
 
 #' @export
 #' @rdname DBI-connection-quote
+setMethod("dbQuoteLiteral", c("Pool", "ANY"),
+  function(conn, x, ...) {
+    connection <- poolCheckout(conn)
+    on.exit(poolReturn(connection))
+    DBI::dbQuoteLiteral(connection, x, ...)
+  }
+)
+
+#' @export
+#' @rdname DBI-connection-quote
 setMethod("dbQuoteString", c("Pool", "ANY"),
   function(conn, x, ...) {
     connection <- poolCheckout(conn)


### PR DESCRIPTION
This PR resolves #96 

`DBI::dbQuoteLiteral()` is used in package `glue (>= 1.3.2)`, making this PR necessary to maintain compatibility between the two packages.