### PR TITLE
Added example for using a DSN with an ODBC driver

### DIFF
--- a/R/DBI.R
+++ b/R/DBI.R
@@ -38,6 +38,7 @@ NULL
 #'
 #' @export
 #' @examples
+#' # Using the RMySQL package
 #' if (requireNamespace("RMySQL", quietly = TRUE)) {
 #'   pool <- dbPool(
 #'     drv = RMySQL::MySQL(),
@@ -59,6 +60,11 @@ NULL
 #'
 #' } else {
 #'   message("Please install the 'RMySQL' package to run this example")
+#' }
+#'
+#' # Using a DSN with an ODBC driver
+#' \dontrun{
+#' pool <- dbPool(odbc::odbc(), dsn = "Data Source Name")
 #' }
 dbPool <- function(drv, ..., validateQuery = NULL) {
   state <- new.env(parent = emptyenv())

--- a/man/dbPool.Rd
+++ b/man/dbPool.Rd
@@ -43,6 +43,7 @@ and it should always be accompanied by the required authorization
 arguments (see the example below).
 }
 \examples{
+# Using the RMySQL package
 if (requireNamespace("RMySQL", quietly = TRUE)) {
   pool <- dbPool(
     drv = RMySQL::MySQL(),
@@ -64,5 +65,10 @@ if (requireNamespace("RMySQL", quietly = TRUE)) {
 
 } else {
   message("Please install the 'RMySQL' package to run this example")
+}
+
+# Using a DSN with an ODBC driver
+\dontrun{
+pool <- dbPool(odbc::odbc(), dsn = "Data Source Name")
 }
 }


### PR DESCRIPTION
This clarifies how to use DSN's with pool. Without this, the solution is not clear, since odbc::dbConnect masks DBI::dbConnect. See issue #60.