### PR TITLE
Use built-in callback cancellation from later

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Depends:
 Imports:
     DBI,
     R6,
-    later
+    later (>= 1.0.0)
 Suggests:
     testthat,
     tibble,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+pool 0.1.5.9000
+================
+
+* Fixed #114: `dbPool()` objects previously could leak memory. (#115)
+
 pool 0.1.5
 ================
 

--- a/R/scheduler.R
+++ b/R/scheduler.R
@@ -4,7 +4,7 @@ NULL
 ## Used in the Pool class to schedule and cancel tasks (based on `later`)
 scheduleTask <- function(func, delay) {
   force(func)
-  later::later(function() {
+  cancel <- later::later(function() {
     # Make sure warn is at least 1 so that warnings are emitted immediately.
     # (warn=2 is also OK, for use in debugging.)
     warn_level <- getOption("warn")
@@ -21,10 +21,7 @@ scheduleTask <- function(func, delay) {
   ##    > cancel <- scheduleTaskRecurring(function() print("hello"), 1)
   ##    [1] "hello"
   ##    [1] "hello"
-  ##    > cancel()
-  function() {
-    func <<- NULL
-  }
+  cancel
 }
 
 ## Used in the Pool class. This function builds on top of `scheduleTask`


### PR DESCRIPTION
Closes #114.

Previously, instead of cancelling the callback immediately, the canceller function would simply assign `func <<- NULL`. That would make the actual callback (which in turn calls `func()`) effectively a no-op, but it would still exist and consume memory.

This change uses the built-in later callback cancellation added in 1.0.0.

With this change, the test code from https://github.com/rstudio/pool/issues/114#issuecomment-742613576 does not leak.


```R
library(pryr)
library(pool)
library(dplyr)

pool <- dbPool(RSQLite::SQLite(), dbname = ":memory:")

# Use dplyr syntax to copy mtcars to object
db_desc(pool)
copy_to(pool, mtcars, "mtcars", temporary = FALSE)

old.mem <- pryr::mem_used()
highest.mem <- old.mem
when <- Sys.time()
i <- 0
while (TRUE) {
  Sys.sleep(0.5)
  x <- dbGetQuery(pool, "SELECT * FROM mtcars LIMIT 5;")
  new.mem <- pryr::mem_used()
  if (new.mem > highest.mem) {
    highest.mem <- new.mem
    when <- as.character(Sys.time())
  }
  diff <- new.mem - old.mem
  old.mem <- new.mem
  
  cat(as.character(Sys.time()), ' Highest: ', highest.mem, ' at ', when, '. Mem now: ', new.mem, ' (', diff, ')\n', sep='')
}
```

Output:

```
2020-12-10 10:14:35 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095472 (11408)

2020-12-10 10:14:35 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095312 (-160)
2020-12-10 10:14:36 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (120)
2020-12-10 10:14:36 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095368 (-64)
2020-12-10 10:14:37 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (64)
2020-12-10 10:14:37 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (0)
2020-12-10 10:14:38 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (0)
2020-12-10 10:14:39 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (0)
2020-12-10 10:14:39 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (0)
2020-12-10 10:14:40 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (0)
2020-12-10 10:14:40 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (0)
2020-12-10 10:14:41 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (0)
2020-12-10 10:14:41 Highest: 79095472 at 2020-12-10 10:14:35. Mem now: 79095432 (0)
```

*****

Note: Using the CRAN version of pool (0.1.5), I tried using a smaller `idleTimeout`, as in the following:

```R
pool <- dbPool(RSQLite::SQLite(), dbname = ":memory:", idleTimeout = 2)
```

I expected it to release the memory after 2 seconds, but that doesn't seem to be the case, and I'm not sure why.