### PR TITLE
Fixing issues with sql_join_suffix with older versions of dbplyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     testthat,
     tibble,
     dplyr,
-    dbplyr,
+    dbplyr (>= 2.0.0),
     RSQLite,
     RMySQL
 Encoding: UTF-8


### PR DESCRIPTION
It appears that `pool` is now relying on the generic `sql_join_suffix` from `dbplyr`.

`dbplyr` didn't introduce this feature until v2.0.0, and so pool can install fine with older versions of dbplyr. 