### PR TITLE
copy_to() should return pooled object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pool (development version)
 
+* `copy_to()` now returns a tbl that uses the Pool.
+
+* Added missing method for `sql_join_suffix()` (#165).
+
 # pool 1.0.0
 
 ## New features

--- a/R/dbplyr.R
+++ b/R/dbplyr.R
@@ -44,17 +44,21 @@ copy_to.Pool <- function(dest,
                          ...) {
   stop_if_temporary(temporary)
 
-  db_con <- poolCheckout(dest)
-  on.exit(poolReturn(db_con))
+  local({
+    db_con <- poolCheckout(dest)
+    on.exit(poolReturn(db_con))
 
-  dplyr::copy_to(
-    dest = db_con,
-    df = df,
-    name = name,
-    overwrite = overwrite,
-    temporary = temporary,
-    ...
-  )
+    dplyr::copy_to(
+      dest = db_con,
+      df = df,
+      name = name,
+      overwrite = overwrite,
+      temporary = temporary,
+      ...
+    )
+  })
+
+  tbl.Pool(dest, name)
 }
 
 # Lazily registered wrapped functions ------------------------------------------
@@ -74,6 +78,7 @@ dbplyr_register_methods <- function() {
     dbplyr_s3_register("db_connection_describe")
     dbplyr_s3_register("db_sql_render")
     dbplyr_s3_register("sql_translation")
+    dbplyr_s3_register("sql_join_suffix")
   })
 }
 

--- a/tests/testthat/test-dbplyr.R
+++ b/tests/testthat/test-dbplyr.R
@@ -8,6 +8,7 @@ test_that("can copy and collect", {
     temporary = FALSE,
     indexes = list(c("x", "y"), "y")
   )
+  expect_s3_class(dbplyr::remote_con(db), "Pool")
   expect_equal(dplyr::collect(db), df)
 
   # But copy_to must not be temporary


### PR DESCRIPTION
And implement `sql_join_suffix()` to fix problem thus revealed. Fixes #165.